### PR TITLE
fix: add types to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }


### PR DESCRIPTION
As per https://publint.dev/eslint-plugin-no-await-in-promise@1.1.3