### PR TITLE
fix: remove types from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,8 @@
   "license": "MIT",
   "author": "Hugo van Rijswijk",
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }


### PR DESCRIPTION
Let the tool figure it out. This works best, apparently
